### PR TITLE
fix interrupted comment

### DIFF
--- a/simplenlg/features/Feature.py
+++ b/simplenlg/features/Feature.py
@@ -31,6 +31,7 @@ class Feature(object):
     # parent clause.
     COMPLEMENTISER = "complementiser"
     # This feature represents the word (or phrase) used for linking coordinated
+    # phrases together.
     CONJUNCTION = "conjunction"
     # This feature represents the type of conjunction this coordination
     # represents.


### PR DESCRIPTION
Tiny change that finishes the sentence in the comment as it appears in  https://github.com/simplenlg/simplenlg/blob/c65331a528f0241c29051c7a086ae5e9518e07e2/src/main/java/simplenlg/features/Feature.java#L210